### PR TITLE
add mobdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Software that makes it easy to consume GTFS data in a variety of languages.
 ##### R
 - [r-transit](https://github.com/r-transit) - Collection of tools for GTFS in R.
 - [gtfsio](https://github.com/r-transit/gtfsio) - Fast and flexible functions to read and write GTFS in R.
+- [mobdb](https://github.com/jasonad123/mobdb) - R functions to search, discover, and access transit feed data from the [Mobility Database](https://mobilitydatabase.org/).
 - [tidytransit](https://github.com/r-transit/tidytransit) - Use tidytransit to map transit stops and routes, calculate travel times and transit frequencies, and validate transit feeds. tidytransit reads the General Transit Feed Specification into tidyverse and simple features data frames.
 
 ##### Ruby


### PR DESCRIPTION
This PR is to add my R package `mobdb` to the list! 

Since it's an R package that's meant to *serve* transit/mobility feeds for onward analysis I wasn't quite sure where to put it, but I figured **Producing Data > GTFS > GTFS Libraries > R** made the most sense.