### PR TITLE
Add TransitLens to GTFS Based Visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ##### Community list of data standards, APIs, apps, tools, datasets, and research around open source technology of public transit.
 
 Open technology provides an opportunity for various stakeholders to collaborate efforts to improve public transit.
-h
+
 Elements of open technology include:
 - Open standards
 - Open data

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ##### Community list of data standards, APIs, apps, tools, datasets, and research around open source technology of public transit.
 
 Open technology provides an opportunity for various stakeholders to collaborate efforts to improve public transit.
-
+h
 Elements of open technology include:
 - Open standards
 - Open data
@@ -516,6 +516,7 @@ Experimental and production transit hardware.
 - [Toronto Transit Explorer](https://github.com/sidewalklabs/totx) - A Java application that visualizes transit, biking and walking accessibility across the city of Toronto. Uses a modified version of [R5](https://github.com/conveyal/r5) for routing.
 - [Transit Vis](https://github.com/zackAemmer/transit_vis) - A visualization tool to display performance metrics derived from the King County Metro GTFS-RT feed (OneBusAway API). Viewable [here](https://www.transitvis.com/). Used for [this paper](https://link.springer.com/article/10.1007/s12469-022-00291-7).
 - [TransitFlow](https://github.com/transitland/transitland-processing-animation) Animate GTFS data around the world using Processing and Transitland.
+- [TransitLens](https://transit-lens.com/gtfs-map-viewer/) - Browser-based GTFS viewer for visualizing routes, stops, and shapes on an interactive map. Includes service calendar analysis, structured data tables, and GeoJSON/KML overlay support. No setup required.
 - [TRAVIC Transit Visualization Client](http://tracker.geops.ch/) - Visualizes vehicles moving based on static GTFS data (and sometimes realtime data). Supports over 260 cities.  Github account for geOps organization is [here](https://github.com/geops).
 - [Traze](https://traze.app/) by [Veridict](https://www.veridict.com) - Visualization of public transport vehicles from all over the world. Collaborate with other users to get real-time updates even when it is not available from the agency. Based on a number of sources, including GTFS and GTFS-RT. (Previously known as Livemap24). 
 - [Visualizing MBTA Data](http://mbtaviz.github.io/) - Interactive graphs that show how people use Boston's subway system.


### PR DESCRIPTION
TransitLens (https://transit-lens.com) is a browser-based GTFS viewer and analysis tool. It renders routes, stops, and shapes on an interactive map, provides structured table views, includes service calendar heatmaps and schedule analysis, and supports GeoJSON/KML polygon overlays for spatial analysis. Runs entirely in the browser with no setup, no account, no server required.

It fits under "GTFS Based Visualizations" as a browser-based GTFS visualization tool.

Full disclosure: I am the developer of TransitLens.