### PR TITLE
Add Timepiecepedia Watch Database to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ Tools for transit agencies.  See also [GTFS Data Collection and Maintenance Tool
 
 ## Resources
 
+- [Timepiecepedia Watch Database](https://github.com/timepiecepedia/timepiecepedia-data) — Free CC0 dataset: 25,876+ watch references across 126 brands, with full specifications (movement, material, diameter, water resistance), imagery URLs, and watchmaking glossary.
 ### Community
 
 Places to ask questions and find other community resources.


### PR DESCRIPTION
Hi! 👋

Thought this would fit your "Resources" section:

**[Timepiecepedia Watch Database](https://github.com/timepiecepedia/timepiecepedia-data)** — a free, CC0-licensed open dataset of 25,876+ watch references across 126 brands, with full specs (movement, case, materials, water resistance), image URLs, and 1,075+ horology terms. The dataset is auto-updated every few hours from [timepiecepedia.com](https://timepiecepedia.com).

Use cases: ML training, watch comparison tools, horology research, collector apps.

No obligation to merge — feel free to close or edit as you see fit. Thanks for maintaining a great list!