### PR TITLE
Update README.md - Update GTFS Express entry (now open source, AGPL-3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Converters from various static schedule formats to and from GTFS.
 - [Amarillo](https://github.com/mfdz/amarillo) - Aggregates and enhances carpooling-offers and publishes them as GTFS(-RT)
 - [GTFS Studio](https://gtfs.studio) - Online editor for GTFS feeds
 - [Uttu](https://github.com/entur/uttu) - Back-end for Nplan, a simple timetable editor.
-- [GTFS Express](https://gtfsexpress.com) - Web application to edit, validate and analyze GTFS feeds — including Fares v2 and GTFS-Flex — with an interactive schedule grid and map editor, an SQL console with AI-assisted natural-language queries, and strict canonical validation via [MobilityData's gtfs-validator](https://github.com/MobilityData/gtfs-validator).
+- [GTFS Express](https://gtfsexpress.com) - Browser app to validate, fix and re-export GTFS feeds end to end. Validate with [MobilityData's canonical validator](https://github.com/MobilityData/gtfs-validator), then fix findings in place: edit every table (point edits in the UI, bulk edits via a SQL console or a natural-language AI), reshape route geometry on a map with Shape Studio (OSRM snap-to-road), and have the AI repair assistant draft a fix, preview the rows it changes, apply it transactionally and re-validate. Full Schedule spec plus Fares v1/v2 and GTFS-Flex, feed-to-feed diff, 8 languages. Open source, AGPL-3.0: [source](https://github.com/Weyland-Binary/gtfs-express).
 
 #### GTFS Merge Tools
 - [combine_gtfs_feeds](https://github.com/psrc/combine_gtfs_feeds) - A Python tool to combine multiple gtfs feeds into one feed/dataset.


### PR DESCRIPTION
GTFS Express is now open source under AGPL-3.0 with a public repository (https://github.com/Weyland-Binary/gtfs-express). Edits the existing entry to add the open-source license + source link, the map-based Shape Studio geometry editor, and the AI repair loop. One line, factual, period-terminated per CONTRIBUTING.