### PR TITLE
Adding CharlieBoard: An open-source hardware/software project for the MBTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Experimental and production transit hardware.
 
 - [Arrivals LED](https://github.com/jdamcd/arrivals-led) - Python renderer that drives a 128×32 HUB75 LED matrix on a Raspberry Pi to display live transit arrivals.
 - [Bus Tracking GPS](https://github.com/herrdragon/busTrackingGps) - Code for Miami prototype of a cheap open-source solution to track transit buses.
+- [CharlieBoard](https://github.com/tomunderwood99/CharlieBoard) - Open-source MBTA display using WS2812B LEDs on a Raspberry Pi Zero 2W, with real-time vehicle positions, geographically accurate PCB map, and a web control interface.
 - [Train departure Display](https://github.com/chrisys/train-departure-display) - A replica, near real-time, miniature UK railway station train departure sign based upon a Raspberry Pi Zer0.
 
 ### SDKs


### PR DESCRIPTION
CharlieBoard is an open-source transit display for the MBTA. It runs on a Raspberry Pi Zero 2W, showing real-time vehicle data on WS2812B LEDs on a custom PCB map. This project is entirely open source (software and hardware) and highly customizable. 