### PR TITLE
Add TrainRouter to Transit Map Aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Experimental and production transit hardware.
 - [AccraMobile3](https://wiki.openstreetmap.org/wiki/AccraMobile3) - Accra Mobile 3 is a project launched in July 2017 to map all the Tro tro lines of Accra, Ghana for the Department of Transport (DoT) of Accra...
 - [OpenStationMap](https://openstationmap.org/#17/52.51022/13.43477/8.8/55) - Displays indoors of public transport stations (including rails and platforms).
 - [gbfs R package](https://github.com/simonpcouch/gbfs) - Functions to interface with GBFS feeds in R, allowing users to save and accumulate tidy .rds datasets for specified cities/bikeshare programs.
+- [TrainRouter](https://trainrouter.com/) - Interactive world atlas of 744 notable train routes (high-speed, scenic and night trains) with facts and photos for each route; the underlying data is open (CC BY 4.0).
 
 ### Agency Tools
 


### PR DESCRIPTION
Adds TrainRouter to the Transit Map Aggregation section.

[TrainRouter](https://trainrouter.com) is a free interactive world atlas of 744 notable train routes — high-speed, scenic and night trains — each plotted on the map with facts (distance, fastest journey time, top speed, operator, opening year) and photos. No signup, no app. It complements the other worldwide rail maps in this section (OpenRailwayMap, UrbanRail.Net, AllRailMap) with a curated named-routes / intercity focus.

The underlying data is open (CC BY 4.0): https://github.com/Flightmussy/trainrouter-atlas — archived on Zenodo, DOI 10.5281/zenodo.21322031.

Disclosure: I'm the author of TrainRouter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)