### PR TITLE
Add GTFS Scorecard to Analysis Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Converters from various static schedule formats to and from GTFS.
 #### GTFS Analysis Tools
 
 - [GTFS Kit](https://github.com/mrcagney/gtfs_kit) - A Python 3.6+ tool kit for analyzing General Transit Feed Specification (GTFS) data. Supersedes [GTFSTK](https://github.com/araichev/gtfstk).
+- [GTFS Scorecard](https://github.com/ChelseaKR/gtfs-scorecard) - Open-source GTFS and GTFS-Realtime quality scorecards for public feeds, with plain-language fixes, a web interface, read API, and GitHub Action.
 - [gtfstools](https://github.com/ipeaGIT/gtfstools) - A set of convenient tools for editing and analysing transit feeds in GTFS format in R.
 - [transit_service_analyst](https://github.com/psrc/transit_service_analyst) - A Python library to support transit service analysis.
 - [Peartree](https://github.com/kuanb/peartree) - A Python library for converting transit data into a directed graph for network analysis.
@@ -717,5 +718,4 @@ This is a community resource for informational use only - listing of a project/p
 This list is built and maintained by open source community contributors like you! [MobilityData](https://mobilitydata.org/) stewards the project. 
 
 #Awesome-transit was originally created by [Luqmaan Dawoodjee](https://github.com/luqmaan) and was stewarded by the [Center for Urban Transportation Research](https://www.cutr.usf.edu/) at the [University of South Florida](http://www.usf.edu/) for several years before the project was transferred to MobilityData.
-
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Converters from various static schedule formats to and from GTFS.
 #### GTFS Analysis Tools
 
 - [GTFS Kit](https://github.com/mrcagney/gtfs_kit) - A Python 3.6+ tool kit for analyzing General Transit Feed Specification (GTFS) data. Supersedes [GTFSTK](https://github.com/araichev/gtfstk).
-- [GTFS Scorecard](https://github.com/ChelseaKR/gtfs-scorecard) - Open-source GTFS and GTFS-Realtime quality scorecards for public feeds, with plain-language fixes, a web interface, read API, and GitHub Action.
+- [GTFS Scorecard](https://github.com/ChelseaKR/gtfs-scorecard) - Daily, open-source GTFS and GTFS-Realtime quality scorecards for 1,100+ public feeds, with rider-focused fix guidance, agency and program views, trend history, a read API, pre-publish checks, and a GitHub Action.
 - [gtfstools](https://github.com/ipeaGIT/gtfstools) - A set of convenient tools for editing and analysing transit feeds in GTFS format in R.
 - [transit_service_analyst](https://github.com/psrc/transit_service_analyst) - A Python library to support transit service analysis.
 - [Peartree](https://github.com/kuanb/peartree) - A Python library for converting transit data into a directed graph for network analysis.
@@ -718,4 +718,3 @@ This is a community resource for informational use only - listing of a project/p
 This list is built and maintained by open source community contributors like you! [MobilityData](https://mobilitydata.org/) stewards the project. 
 
 #Awesome-transit was originally created by [Luqmaan Dawoodjee](https://github.com/luqmaan) and was stewarded by the [Center for Urban Transportation Research](https://www.cutr.usf.edu/) at the [University of South Florida](http://www.usf.edu/) for several years before the project was transferred to MobilityData.
-

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Converters from various static schedule formats to and from GTFS.
 #### GTFS Analysis Tools
 
 - [GTFS Kit](https://github.com/mrcagney/gtfs_kit) - A Python 3.6+ tool kit for analyzing General Transit Feed Specification (GTFS) data. Supersedes [GTFSTK](https://github.com/araichev/gtfstk).
-- [GTFS Scorecard](https://github.com/ChelseaKR/gtfs-scorecard) - Daily, open-source GTFS and GTFS-Realtime quality scorecards for 1,100+ public feeds, with rider-focused fix guidance, agency and program views, trend history, a read API, pre-publish checks, and a GitHub Action.
+- [GTFS Scorecard](https://github.com/ChelseaKR/gtfs-scorecard) - Daily, open-source GTFS and GTFS-Realtime quality scoring for a curated registry of 1,700+ feed records with 1,100+ published scorecards, rider-focused fix guidance, agency and program views, trend history, a read API, pre-publish checks, and a GitHub Action.
 - [gtfstools](https://github.com/ipeaGIT/gtfstools) - A set of convenient tools for editing and analysing transit feeds in GTFS format in R.
 - [transit_service_analyst](https://github.com/psrc/transit_service_analyst) - A Python library to support transit service analysis.
 - [Peartree](https://github.com/kuanb/peartree) - A Python library for converting transit data into a directed graph for network analysis.


### PR DESCRIPTION
## What changed

Adds GTFS Scorecard to the GTFS Analysis Tools section as one individual
suggestion.

The catalog line summarizes the project's current public scope: daily GTFS and
GTFS-Realtime quality scoring for a curated registry of more than 1,700 feed
records with more than 1,100 published scorecards, rider-focused fix guidance,
agency and program views, trend history, a read API, pre-publish checks, and a
GitHub Action.

## Why

GTFS Scorecard turns canonical validator results and feed-health checks into
actionable information for transit staff, while also publishing program-level
and machine-readable views for support organizations and downstream users.

## Impact

Transit feed maintainers, support programs, and developers browsing this
catalog gain another open-source option for feed-quality analysis and
remediation. The listing links directly to the public repository and does not
imply endorsement.

## Validation

- Confirmed the project was not already listed.
- Placed it in the existing GTFS Analysis Tools category.
- Kept the contribution to one suggestion.
- Checked the description against the current project README and public
  repository metadata.
- Ran `git diff --check`.
